### PR TITLE
Refactor backend and frontend, add tests and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "18"
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.12"
+          cache: "pip"
+      - name: Install dependencies
+        run: |
+          corepack enable
+          corepack prepare pnpm@9.15.4 --activate
+          pnpm install
+          pip install -r requirements.txt
+      - name: Run ESLint
+        run: pnpm lint
+      - name: Run pytest
+        run: pytest -q

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ Originally adapted from the example-tauri-python-server-sidecar by dieharders, i
 .
 ├── app/                 # Next.js frontend source code (TypeScript/React)
 ├── src/backends/        # Python backend (FastAPI)
-│   ├── config.json      # Configuration (API URLs, etc.)
-│   └── main.py          # API endpoints & logic
+│   ├── config.json.example  # Template configuration
+│   └── main.py          # API entry point used by the sidecar
 ├── src-tauri/
 │   ├── bin/api          # Compiled Python sidecar executables
 │   ├── src/main.rs      # Tauri (Rust) main application logic
@@ -58,6 +58,9 @@ Originally adapted from the example-tauri-python-server-sidecar by dieharders, i
 Install both frontend and backend dependencies with:
 
 pnpm install-reqs
+
+Copy `src/backends/config.json.example` to `src/backends/config.json` and
+update the `redash_csv_url` value to point at your CSV export.
 
 	•	Frontend-only:
 
@@ -102,6 +105,12 @@ pnpm build:sidecar-linux
 
 To build a production-ready version:
 
+pnpm tauri build
+
+In sequence:
+
+pnpm install-reqs
+pnpm build:sidecar-<platform>
 pnpm tauri build
 
 Your compiled installers and executables are located in:

--- a/app/components/Logs.tsx
+++ b/app/components/Logs.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+interface Props {
+  logs: string;
+}
+
+export default function Logs({ logs }: Props) {
+  return (
+    <code className="mt-6 w-full max-w-[1200px] max-h-96 border border-gray-300 rounded-lg bg-gray-100 p-4 text-sm whitespace-pre-wrap overflow-y-auto">
+      {logs}
+    </code>
+  );
+}

--- a/app/components/ResultsTable.tsx
+++ b/app/components/ResultsTable.tsx
@@ -1,0 +1,69 @@
+"use client";
+import { useState } from "react";
+
+interface Props {
+  results: any[];
+}
+
+export default function ResultsTable({ results }: Props) {
+  const [expandedCell, setExpandedCell] = useState<{ rowIndex: number; colKey: string } | null>(null);
+
+  const toggle = (rowIndex: number, colKey: string) => {
+    if (expandedCell && expandedCell.rowIndex === rowIndex && expandedCell.colKey === colKey) {
+      setExpandedCell(null);
+    } else {
+      setExpandedCell({ rowIndex, colKey });
+    }
+  };
+
+  const truncateCellClasses =
+    "inline-block overflow-hidden text-ellipsis whitespace-nowrap cursor-pointer max-w-[120px] align-top";
+  const expandedCellClasses =
+    "inline-block whitespace-normal break-words bg-yellow-100 p-1 rounded cursor-pointer align-top";
+
+  if (results.length === 0) {
+    return <p className="italic text-gray-700">No results yet.</p>;
+  }
+
+  return (
+    <div className="w-full max-w-5xl rounded-lg bg-white shadow-md p-4 border border-gray-300">
+      <h3 className="font-bold mb-2 text-gray-900">Search Results:</h3>
+      <div className="overflow-x-auto">
+        <table className="border-collapse w-full text-left text-sm text-gray-800">
+          <thead>
+            <tr>
+              {Object.keys(results[0]).map((colKey) => (
+                <th key={colKey} className="border-b border-gray-200 px-2 py-2 bg-gray-100 font-bold">
+                  {colKey}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {results.map((row, rowIndex) => (
+              <tr key={rowIndex}>
+                {Object.keys(row).map((colKey) => {
+                  const cellValue = String(row[colKey]);
+                  const isExpanded = expandedCell && expandedCell.rowIndex === rowIndex && expandedCell.colKey === colKey;
+                  return (
+                    <td
+                      key={colKey}
+                      className="border-b border-gray-200 px-2 py-2 align-top"
+                      onClick={() => toggle(rowIndex, colKey)}
+                    >
+                      {isExpanded ? (
+                        <div className={expandedCellClasses}>{cellValue}</div>
+                      ) : (
+                        <div className={truncateCellClasses}>{cellValue}</div>
+                      )}
+                    </td>
+                  );
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/app/components/SearchForm.tsx
+++ b/app/components/SearchForm.tsx
@@ -1,0 +1,35 @@
+"use client";
+import { useState } from "react";
+
+interface Props {
+  onSearch: (keyword: string) => void;
+}
+
+export default function SearchForm({ onSearch }: Props) {
+  const [keyword, setKeyword] = useState("");
+
+  const submit = () => {
+    onSearch(keyword);
+  };
+
+  return (
+    <div className="w-full max-w-xl mb-6">
+      <input
+        type="text"
+        placeholder="Search keyword..."
+        className="border p-2 rounded w-full bg-white text-black"
+        value={keyword}
+        onChange={(e) => setKeyword(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") submit();
+        }}
+      />
+      <button
+        onClick={submit}
+        className="mt-2 bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded"
+      >
+        Search CSV
+      </button>
+    </div>
+  );
+}

--- a/app/hooks/useApi.ts
+++ b/app/hooks/useApi.ts
@@ -1,0 +1,26 @@
+"use client";
+import { useCallback } from "react";
+
+const DOMAIN = "localhost";
+const PORT = "8008";
+
+export function useApi() {
+  const apiAction = useCallback(
+    async (endpoint: string, method = "GET", payload?: any) => {
+      const url = `http://${DOMAIN}:${PORT}/${endpoint}`;
+      const body = payload ? JSON.stringify(payload) : null;
+      const headers = { "Content-Type": "application/json" };
+      const res = await fetch(url, { method, headers, body });
+      if (!res.ok) throw new Error(`Response status: ${res.status}`);
+      return res.json();
+    },
+    []
+  );
+
+  const search = useCallback(
+    (keyword: string) => apiAction(`api/search?keyword=${encodeURIComponent(keyword)}`),
+    [apiAction]
+  );
+
+  return { apiAction, search };
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,34 +3,39 @@
 import { useEffect, useState } from "react";
 import { listen } from "@tauri-apps/api/event";
 import { invoke } from "@tauri-apps/api/core";
+import SearchForm from "./components/SearchForm";
+import ResultsTable from "./components/ResultsTable";
+import { useApi } from "./hooks/useApi";
 
 export default function Home() {
-  const DOMAIN = "localhost";
-  const PORT = "8008";
-
   const [logs, setLogs] = useState("[ui] Listening for sidecar & network logs...");
-  const [keyword, setKeyword] = useState("");
-  const [searchResults, setSearchResults] = useState<any[]>([]);
+  const [results, setResults] = useState<any[]>([]);
   const [isConnecting, setIsConnecting] = useState(true);
+  const { search } = useApi();
 
-  // Track which cell is expanded (row + column).
-  const [expandedCell, setExpandedCell] = useState<{
-    rowIndex: number;
-    colKey: string;
-  } | null>(null);
+  const performSearch = async (keyword: string) => {
+    if (!keyword) {
+      setLogs((prev) => prev + "\n[ui] Please enter a keyword to search.");
+      return;
+    }
+    try {
+      const res = await search(keyword);
+      if (res?.results) {
+        setResults(res.results);
+        setLogs((prev) => prev + `\n[ui] Found ${res.results.length} matching rows.`);
+      }
+    } catch (err) {
+      setLogs((prev) => prev + `\n[ui] ${err}`);
+    }
+  };
 
-  // ----------------------------
-  // Sidecar listeners
-  // ----------------------------
   const initSidecarListeners = async () => {
     const unlistenStdout = await listen("sidecar-stdout", (event) => {
-      console.log("Sidecar stdout:", event.payload);
       if (`${event.payload}`.length > 0 && event.payload !== "\r\n") {
         setLogs((prev) => prev + `\n${event.payload}`);
       }
     });
     const unlistenStderr = await listen("sidecar-stderr", (event) => {
-      console.error("Sidecar stderr:", event.payload);
       if (`${event.payload}`.length > 0 && event.payload !== "\r\n") {
         setLogs((prev) => prev + `\n${event.payload}`);
       }
@@ -41,73 +46,10 @@ export default function Home() {
     };
   };
 
-  // ----------------------------
-  // Simple fetch helper
-  // ----------------------------
-  const apiAction = async (
-    endpoint: string,
-    method: string = "GET",
-    payload?: any
-  ) => {
-    const url = `http://${DOMAIN}:${PORT}/${endpoint}`;
-    try {
-      const body = payload ? JSON.stringify(payload) : null;
-      const headers = { "Content-Type": "application/json" };
-      const res = await fetch(url, { method, headers, body });
-      if (!res.ok) {
-        throw new Error(`Response status: ${res.status}`);
-      }
-      const json = await res.json();
-      console.log(json);
-
-      // Log success message from server
-      if (json?.message) {
-        setLogs((prev) => prev + `\n[server-response] ${json.message}`);
-      }
-      return json;
-    } catch (err) {
-      console.error(`[server-response] ${err}`);
-      setLogs((prev) => prev + `\n[server-response] ${err}`);
-    }
-  };
-
-  // ----------------------------
-  // Perform a search
-  // ----------------------------
-  const performSearch = async () => {
-    if (!keyword) {
-      setLogs((prev) => prev + "\n[ui] Please enter a keyword to search.");
-      return;
-    }
-    const result = await apiAction(
-      `api/search?keyword=${encodeURIComponent(keyword)}`
-    );
-    if (result?.results) {
-      setSearchResults(result.results);
-      setLogs((prev) => prev + `\n[ui] Found ${result.results.length} matching rows.`);
-      setExpandedCell(null); // reset any expanded cell when new data arrives
-    }
-  };
-
-  // ----------------------------
-  // Toggle cell expansion
-  // ----------------------------
-  const toggleCellExpand = (rowIndex: number, colKey: string) => {
-    if (expandedCell && expandedCell.rowIndex === rowIndex && expandedCell.colKey === colKey) {
-      setExpandedCell(null); // collapse if same cell clicked again
-    } else {
-      setExpandedCell({ rowIndex, colKey });
-    }
-  };
-
-  // ----------------------------
-  // Lifecycle Hooks
-  // ----------------------------
   useEffect(() => {
     initSidecarListeners();
   }, []);
 
-  // Handle F11 for fullscreen
   useEffect(() => {
     const listener = (event: KeyboardEvent) => {
       if (event.key === "F11") {
@@ -119,31 +61,21 @@ export default function Home() {
     return () => window.removeEventListener("keydown", listener);
   }, []);
 
-  // Health check polling
   useEffect(() => {
     const intervalId = setInterval(async () => {
       try {
-        const res = await fetch(`http://${DOMAIN}:${PORT}/api/health`);
+        const res = await fetch("http://localhost:8008/api/health");
         if (res.ok) {
           setIsConnecting(false);
           setLogs((prev) => prev + "\n[ui] Backend connected successfully.");
           clearInterval(intervalId);
         }
-      } catch (err) {
+      } catch {
         setLogs((prev) => prev + "\n[ui] Waiting for backend to connect...");
       }
     }, 1000);
-
     return () => clearInterval(intervalId);
   }, []);
-
-  // ----------------------------
-  // Styles for truncated vs. expanded
-  // ----------------------------
-  const truncateCellClasses =
-    "inline-block overflow-hidden text-ellipsis whitespace-nowrap cursor-pointer max-w-[120px] align-top";
-  const expandedCellClasses =
-    "inline-block whitespace-normal break-words bg-yellow-100 p-1 rounded cursor-pointer align-top";
 
   return (
     <>
@@ -154,95 +86,14 @@ export default function Home() {
         </main>
       ) : (
         <main className="flex min-h-screen flex-col items-center p-8 bg-gray-200">
-          {/* Header */}
           <header className="w-full mb-8 text-center">
             <h1 className="text-3xl font-bold text-gray-900">Redash Search App</h1>
           </header>
-
-          {/* Search Input & Button */}
-          <div className="w-full max-w-xl mb-6">
-            <input
-              type="text"
-              placeholder="Search keyword..."
-              className="border p-2 rounded w-full bg-white text-black"
-              value={keyword}
-              onChange={(e) => setKeyword(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") {
-                  performSearch();
-                }
-              }}
-            />
-            <button
-              onClick={performSearch}
-              className="mt-2 bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded"
-            >
-              Search CSV
-            </button>
-          </div>
-
-          {/* Search Results Container */}
-          <div className="w-full max-w-5xl rounded-lg bg-white shadow-md p-4 border border-gray-300">
-            <h3 className="font-bold mb-2 text-gray-900">Search Results:</h3>
-
-            {searchResults.length > 0 ? (
-              // We wrap the table in an overflow-x-auto container
-              <div className="overflow-x-auto">
-                <table className="border-collapse w-full text-left text-sm text-gray-800">
-                  <thead>
-                    <tr>
-                      {Object.keys(searchResults[0]).map((colKey) => (
-                        <th
-                          key={colKey}
-                          className="border-b border-gray-200 px-2 py-2 bg-gray-100 font-bold"
-                        >
-                          {colKey}
-                        </th>
-                      ))}
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {searchResults.map((row, rowIndex) => (
-                      <tr key={rowIndex}>
-                        {Object.keys(row).map((colKey) => {
-                          const cellValue = String(row[colKey]);
-                          const isExpanded =
-                            expandedCell &&
-                            expandedCell.rowIndex === rowIndex &&
-                            expandedCell.colKey === colKey;
-
-                          return (
-                            <td
-                              key={colKey}
-                              className="border-b border-gray-200 px-2 py-2 align-top"
-                              onClick={() => toggleCellExpand(rowIndex, colKey)}
-                            >
-                              {isExpanded ? (
-                                <div className={expandedCellClasses}>{cellValue}</div>
-                              ) : (
-                                <div className={truncateCellClasses}>{cellValue}</div>
-                              )}
-                            </td>
-                          );
-                        })}
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            ) : (
-              <p className="italic text-gray-700">No results yet.</p>
-            )}
-          </div>
-
-          {/* Uncomment below to show logs if desired */}
-          {/*
-          <code className="mt-6 w-full max-w-[1200px] max-h-96 border border-gray-300 rounded-lg bg-gray-100 p-4 text-sm whitespace-pre-wrap overflow-y-auto">
-            {logs}
-          </code>
-          */}
+          <SearchForm onSearch={performSearch} />
+          <ResultsTable results={results} />
         </main>
       )}
     </>
   );
 }
+

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   "scripts": {
     "install-reqs": "pnpm install && pip3 install -r requirements.txt",
     "dev": "next dev",
-    "build:sidecar-winos": "pyinstaller -c -F --clean --add-data \"src/backends/config.json;.\" --name main-x86_64-pc-windows-msvc --distpath src-tauri/bin/api src/backends/main.py",
-    "build:sidecar-macos": "pyinstaller -c -F --clean --add-data \"src/backends/config.json:.\" --name main-aarch64-apple-darwin --distpath src-tauri/bin/api src/backends/main.py",
-    "build:sidecar-linux": "pyinstaller -c -F --clean --add-data \"src/backends/config.json:.\" --name main-x86_64-unknown-linux-gnu --distpath src-tauri/bin/api src/backends/main.py",
+    "build:sidecar-winos": "pyinstaller -c -F --clean --add-data \"src/backends/config.json.example;.\" --name main-x86_64-pc-windows-msvc --distpath src-tauri/bin/api src/backends/main.py",
+    "build:sidecar-macos": "pyinstaller -c -F --clean --add-data \"src/backends/config.json.example:.\" --name main-aarch64-apple-darwin --distpath src-tauri/bin/api src/backends/main.py",
+    "build:sidecar-linux": "pyinstaller -c -F --clean --add-data \"src/backends/config.json.example:.\" --name main-x86_64-unknown-linux-gnu --distpath src-tauri/bin/api src/backends/main.py",
     "build:icons": "pnpm tauri icon public/app-icon.png",
     "build": "next build",
     "tauri": "tauri",

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi==0.95.2
 uvicorn[standard]
 sse-starlette==1.6.5
 pyinstaller==5.13.0
+pytest==8.1.1

--- a/src/backends/api/__init__.py
+++ b/src/backends/api/__init__.py
@@ -1,0 +1,6 @@
+from .server import app, main
+from .config import load_config
+from .data import fetch_csv_data
+from .search import search_data
+
+__all__ = ["app", "main", "load_config", "fetch_csv_data", "search_data"]

--- a/src/backends/api/config.py
+++ b/src/backends/api/config.py
@@ -1,0 +1,18 @@
+import json
+import os
+import sys
+
+
+def load_config():
+    """Load configuration from file or environment."""
+    if "REDASH_CSV_URL" in os.environ:
+        return {"redash_csv_url": os.environ["REDASH_CSV_URL"]}
+
+    if hasattr(sys, "_MEIPASS"):
+        base_path = sys._MEIPASS
+    else:
+        base_path = os.path.abspath(".")
+
+    config_path = os.path.join(base_path, "config.json")
+    with open(config_path) as f:
+        return json.load(f)

--- a/src/backends/api/data.py
+++ b/src/backends/api/data.py
@@ -1,0 +1,14 @@
+import csv
+from io import StringIO
+import requests
+
+from .config import load_config
+
+
+def fetch_csv_data():
+    """Download CSV from configured URL and return rows."""
+    config = load_config()
+    response = requests.get(config["redash_csv_url"])
+    response.raise_for_status()
+    reader = csv.DictReader(StringIO(response.text))
+    return list(reader)

--- a/src/backends/api/search.py
+++ b/src/backends/api/search.py
@@ -1,0 +1,21 @@
+def search_data(data, keyword, columns=None, exact=False):
+    """Search rows for keyword."""
+    results = []
+    keyword_lower = keyword.lower()
+
+    for row in data:
+        fields = [row[col] for col in columns if col in row] if columns else row.values()
+        match_found = False
+        for value in fields:
+            val_str = str(value).lower()
+            if exact:
+                if val_str == keyword_lower:
+                    match_found = True
+                    break
+            else:
+                if keyword_lower in val_str:
+                    match_found = True
+                    break
+        if match_found:
+            results.append(row)
+    return results

--- a/src/backends/api/server.py
+++ b/src/backends/api/server.py
@@ -1,0 +1,32 @@
+import os
+from fastapi import FastAPI, Query
+from fastapi.middleware.cors import CORSMiddleware
+import uvicorn
+
+from .data import fetch_csv_data
+from .search import search_data
+
+PORT_API = int(os.environ.get("PORT", 8008))
+
+app = FastAPI(title="Redash CSV Search API", version="0.1.0")
+app.add_middleware(CORSMiddleware, allow_origins=["*"], allow_methods=["*"], allow_headers=["*"])
+
+
+@app.get("/api/search")
+def api_search(keyword: str = Query(...), exact: bool = False):
+    data = fetch_csv_data()
+    results = search_data(data, keyword, exact=exact)
+    return {"results": results, "count": len(results)}
+
+
+@app.get("/api/health")
+def api_health():
+    return {"status": "API running", "port": PORT_API}
+
+
+def main():
+    uvicorn.run(app, host="0.0.0.0", port=PORT_API, log_level="info")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/backends/config.json.example
+++ b/src/backends/config.json.example
@@ -1,0 +1,3 @@
+{
+  "redash_csv_url": "https://example.com/path/to/query.csv"
+}

--- a/src/backends/main.py
+++ b/src/backends/main.py
@@ -3,99 +3,17 @@ import signal
 import sys
 import asyncio
 import threading
-import json
-import requests
-import csv
-from io import StringIO
-from typing import TypedDict
-from fastapi import FastAPI, Body, Query
-from fastapi.middleware.cors import CORSMiddleware
 from uvicorn import Config, Server
+
+from api import app
 
 PORT_API = 8008
 server_instance = None
 
-app = FastAPI(
-    title="Redash CSV Search API",
-    version="0.1.0",
-)
-
-# Configure CORS settings (for dev/testing purposes)
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=["*"],
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
-
-# Load configuration from config.json
-def load_config():
-    # Correctly handles PyInstaller bundles
-    if hasattr(sys, '_MEIPASS'):
-        base_path = sys._MEIPASS
-    else:
-        base_path = os.path.abspath(".")
-
-    config_path = os.path.join(base_path, 'config.json')
-
-    with open(config_path) as f:
-        return json.load(f)
-
-# CSV fetching logic
-def fetch_csv_data():
-    config = load_config()
-    response = requests.get(config['redash_csv_url'])
-    response.raise_for_status()
-    reader = csv.DictReader(StringIO(response.text))
-    return list(reader)
-
-# Your provided CSV search logic (copied from searcher.py)
-def search_data(data, keyword, columns=None, exact=False):
-    results = []
-    keyword_lower = keyword.lower()
-
-    for row in data:
-        if columns:
-            fields_to_check = [row[col] for col in columns if col in row]
-        else:
-            fields_to_check = row.values()
-
-        match_found = False
-        for value in fields_to_check:
-            val_str = str(value).lower()
-            if exact:
-                if val_str == keyword_lower:
-                    match_found = True
-                    break
-            else:
-                if keyword_lower in val_str:
-                    match_found = True
-                    break
-
-        if match_found:
-            results.append(row)
-
-    return results
-
-# API endpoint to search your CSV
-@app.get("/api/search")
-def api_search(keyword: str = Query(...), exact: bool = False):
-    try:
-        data = fetch_csv_data()
-        results = search_data(data, keyword, exact=exact)
-        return {"results": results, "count": len(results)}
-    except Exception as e:
-        return {"error": str(e)}
-
-# Simple health check endpoint
-@app.get("/api/health")
-def api_health():
-    return {"status": "API running", "port": PORT_API}
-
-# --- (Rest of the server code below remains unchanged) ---
 
 def kill_process():
     os.kill(os.getpid(), signal.SIGINT)
+
 
 def start_api_server(**kwargs):
     global server_instance
@@ -111,24 +29,26 @@ def start_api_server(**kwargs):
     except Exception as e:
         print(f"[sidecar] Error starting server: {e}", flush=True)
 
+
 def stdin_loop():
     print("[sidecar] Waiting for commands...", flush=True)
     while True:
         user_input = sys.stdin.readline().strip()
-        match user_input:
-            case "sidecar shutdown":
-                print("[sidecar] Received 'sidecar shutdown' command.", flush=True)
-                kill_process()
-            case _:
-                print(f"[sidecar] Invalid command [{user_input}].", flush=True)
+        if user_input == "sidecar shutdown":
+            print("[sidecar] Received 'sidecar shutdown' command.", flush=True)
+            kill_process()
+        else:
+            print(f"[sidecar] Invalid command [{user_input}].", flush=True)
+
 
 def start_input_thread():
     try:
         input_thread = threading.Thread(target=stdin_loop)
         input_thread.daemon = True
         input_thread.start()
-    except:
+    except Exception:
         print("[sidecar] Failed to start input handler.", flush=True)
+
 
 if __name__ == "__main__":
     start_input_thread()

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,0 +1,29 @@
+import os
+import types
+
+import pytest
+
+from src.backends.api.data import fetch_csv_data
+
+
+class MockResponse:
+    def __init__(self, text=""):
+        self.text = text
+
+    def raise_for_status(self):
+        pass
+
+
+def test_fetch_csv_data(monkeypatch):
+    csv_text = "a,b\n1,2\n"
+
+    def mock_get(url):
+        assert url == "http://example.com/data.csv"
+        return MockResponse(csv_text)
+
+    monkeypatch.setenv("REDASH_CSV_URL", "http://example.com/data.csv")
+    import requests
+    monkeypatch.setattr(requests, "get", mock_get)
+
+    rows = fetch_csv_data()
+    assert rows == [{"a": "1", "b": "2"}]

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,0 +1,19 @@
+from src.backends.api.search import search_data
+
+
+def test_search_data_partial():
+    data = [
+        {"name": "Alice", "age": "30"},
+        {"name": "Bob", "age": "25"},
+    ]
+    results = search_data(data, "ali", columns=["name"], exact=False)
+    assert results == [{"name": "Alice", "age": "30"}]
+
+
+def test_search_data_exact():
+    data = [
+        {"name": "Alice"},
+        {"name": "Alice Smith"},
+    ]
+    results = search_data(data, "Alice", columns=["name"], exact=True)
+    assert results == [{"name": "Alice"}]


### PR DESCRIPTION
## Summary
- modularize Python backend under `api` package
- add unit tests for `fetch_csv_data` and `search_data`
- expose `main` entry in `server.py`
- create React components and API hook
- document configuration template and build sequence
- add CI workflow

## Testing
- `pnpm lint` *(fails: error downloading pnpm)*
- `pip install -r requirements.txt` *(fails: could not connect to proxy)*
- `pytest -q` *(fails: command not found)*