### PR TITLE
Ensure tests import src modules

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# Ensure repository root is on sys.path for imports
+repo_root = Path(__file__).resolve().parents[1]
+if str(repo_root) not in sys.path:
+    sys.path.insert(0, str(repo_root))


### PR DESCRIPTION
## Summary
- make repository root discoverable in tests

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*